### PR TITLE
fix: remove redundant SetSysvarRentAccount call in NewCreateIdempoten…

### DIFF
--- a/programs/associated-token-account/createidempotent.go
+++ b/programs/associated-token-account/createidempotent.go
@@ -229,6 +229,5 @@ func NewCreateIdempotentInstructionWithDerivation(
 		SetWalletAccount(wallet).
 		SetMintAccount(mint).
 		SetSystemProgramAccount(ag_solanago.SystemProgramID).
-		SetTokenProgramAccount(tokenProgram).
-		SetSysvarRentAccount(ag_solanago.SysVarRentPubkey)
+		SetTokenProgramAccount(tokenProgram)
 }


### PR DESCRIPTION
…tInstructionWithDerivation