### PR TITLE
fix: use Params() function in CallForInto and CallWithCallback

### DIFF
--- a/rpc/jsonrpc/jsonrpc.go
+++ b/rpc/jsonrpc/jsonrpc.go
@@ -383,11 +383,8 @@ func (client *rpcClient) CallForInto(
 ) error {
 	request := &RPCRequest{
 		Method:  method,
+		Params:  Params(params...),
 		JSONRPC: jsonrpcVersion,
-	}
-
-	if params != nil {
-		request.Params = params
 	}
 
 	rpcResponse, err := client.doCall(ctx, request)
@@ -410,11 +407,8 @@ func (client *rpcClient) CallWithCallback(
 ) error {
 	request := &RPCRequest{
 		Method:  method,
+		Params:  Params(params...),
 		JSONRPC: jsonrpcVersion,
-	}
-
-	if params != nil {
-		request.Params = params
 	}
 
 	return client.doCallWithCallbackOnHTTPResponse(


### PR DESCRIPTION
### Changes
- CallForInto: Now uses Params(params...) instead of direct assignment
- CallWithCallback: Now uses Params(params...) instead of direct assignment

### Summary
Applied the same Params(params...) pattern used in other RPC methods (Call, CallFor, etc.) to ensure consistent JSON-RPC spec compliance across all client methods.